### PR TITLE
Added offset-slide support for UICollectionView

### DIFF
--- a/lib/CTBottomSlideController.swift
+++ b/lib/CTBottomSlideController.swift
@@ -161,13 +161,21 @@ public class CTBottomSlideController : NSObject, UIGestureRecognizerDelegate
     
     public func set(table:UITableView)
     {
-        if (scrollView != nil){
-            self.removeKVO(scrollView: scrollView!)
+        set(scrollView: table)
+    }
+    
+    public func set(collectionView: UICollectionView) {
+        set(scrollView: collectionView)
+    }
+    
+    public func set(scrollView: UIScrollView){
+        if (self.scrollView != nil){
+            self.removeKVO(scrollView: self.scrollView!)
         }
         
-        scrollView = table;
+        self.scrollView = scrollView;
         //scrollView!.panGestureRecognizer.require(toFail: panGestureRecognizer)
-        self.addKVO(scrollView: scrollView!);
+        self.addKVO(scrollView: self.scrollView!);
     }
     
     


### PR DESCRIPTION
The sliding panel can already slide up or down depending on a [**UIScrollView**](https://developer.apple.com/documentation/uikit/uiscrollview)'s offset, but its setter was limited to only [**UITableView**](https://developer.apple.com/documentation/uikit/uitableview). 

Per my use-case, I've introduced two new setter methods to open up this functionality to [**UICollectionView**](https://developer.apple.com/documentation/uikit/uicollectionview) and (for more general purposes,) [**UIScrollView**](https://developer.apple.com/documentation/uikit/uiscrollview):

`set(scrollView: UIScrollView)`
`set(collectionView: UICollectionView )`
